### PR TITLE
Fix Tailwind font utilities in layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
         <link rel="icon" href="/favicon.ico" />
       </head>
       <body
-        className={`font-sansantialiased bg-background text-foreground bg-gray-900`}
+        className={`font-sans antialiased bg-background text-foreground bg-gray-900`}
       >
         <header className="p-4 bg-primary-color bg-gray-800 drop-shadow-lg rounded-3xl mx-4 my-5 shadow-black text-white flex flex-col items-center">
           <h1 className="text-3xl font-bold mb-2">Welcome to the GPT-4o Voice Generator</h1>


### PR DESCRIPTION
## Summary
- correct the `className` on the `<body>` element

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68416627e35083209e5c5891c2461d86